### PR TITLE
Make Card style with material ui

### DIFF
--- a/src/components/atoms/Card/index.tsx
+++ b/src/components/atoms/Card/index.tsx
@@ -9,7 +9,9 @@ import DeleteIcon from "@material-ui/icons/Delete";
 
 const useStyles = makeStyles({
   root: {
-    background: "linear-gradient(45deg, gray 30%, white 90%)"
+    "&:hover": {
+      backgroundColor: "whitesmoke"
+    }
   }
 });
 

--- a/src/components/atoms/Card/index.tsx
+++ b/src/components/atoms/Card/index.tsx
@@ -4,22 +4,33 @@ import {
   CardHeader,
   IconButton
 } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
 import DeleteIcon from "@material-ui/icons/Delete";
+
+const useStyles = makeStyles({
+  root: {
+    background: "linear-gradient(45deg, gray 30%, white 90%)"
+  }
+});
 
 interface Props {
   title: string;
   onClick: any;
 }
 
-export const Card: React.FC<Props> = ({ title, onClick }) => (
-  <CardComponent>
-    <CardHeader
-      action={
-        <IconButton aria-label="delete" onClick={onClick}>
-          <DeleteIcon />
-        </IconButton>
-      }
-      title={title}
-    />
-  </CardComponent>
-);
+export const Card: React.FC<Props> = ({ title, onClick }) => {
+  const classes = useStyles();
+
+  return (
+    <CardComponent className={classes.root}>
+      <CardHeader
+        action={
+          <IconButton aria-label="delete" onClick={onClick}>
+            <DeleteIcon />
+          </IconButton>
+        }
+        title={title}
+      />
+    </CardComponent>
+  );
+};

--- a/src/components/atoms/Card/index.tsx
+++ b/src/components/atoms/Card/index.tsx
@@ -10,7 +10,8 @@ import DeleteIcon from "@material-ui/icons/Delete";
 const useStyles = makeStyles({
   root: {
     "&:hover": {
-      backgroundColor: "whitesmoke"
+      backgroundColor: "whitesmoke",
+      cursor: "pointer"
     }
   }
 });


### PR DESCRIPTION
material-ui の makeStyle の使い方は以下を参照
https://material-ui.com/styles/basics/#hook-api
https://material-ui.com/styles/basics/#nesting-selectors
https://material-ui.com/styles/api/#makestyles-styles-options-hook

hover style の当て方は以下を参照
https://stackoverflow.com/questions/52596070/materialui-custom-hover-style

hover 時の css の cursor は pointer にした（あとで grab 時は `cursor: "grab"` になるようにするかも）
https://developer.mozilla.org/ja/docs/Web/CSS/cursor